### PR TITLE
Fix for mergeColorMaps() function.

### DIFF
--- a/stylus/utilities/functions.styl
+++ b/stylus/utilities/functions.styl
@@ -1,14 +1,26 @@
+listTypeofValuesValidator($list, $type= 'rgba|hsla')
+  _void= 0;
+  for v, i in $list
+    if match('\b(' + $type + ')\b', typeof(v)) != null
+      _void = _void + 1;
+
+  if length($list) != _void
+    error("Unexpected type inside the list.")
+    return false;
+
+  return true;
+
 mergeColorMaps($bulma-colors, $custom-colors)
   // We return at least Bulma's hard-coded colors
   $merged-colors = $bulma-colors
 
   // We want a map as input
-  if typeof($custom-colors) == 'map'
-    each $name, $components in $custom-colors
+  if typeof($custom-colors) == 'object'
+    for $name, $components in $custom-colors
       // The color name should be a string
       // and the components either a single color
       // or a colors list with at least one element
-      if typeof($name) == 'string' and (typeof($components) == 'list' or typeof($components) == 'color') and length($components) >= 1
+      if typeof($name) == 'string' and (typeof($components) == 'ident' or listTypeofValuesValidator($components, 'rgba|hsla')) and length($components) >= 1
         $color-base = null
         $color-invert = null
         $color-light = null
@@ -17,26 +29,26 @@ mergeColorMaps($bulma-colors, $custom-colors)
 
         // The param can either be a single color
         // or a list of 2 colors
-        if typeof($components) == 'color'
+        if listTypeofValuesValidator($components, 'rgba|hsla') and length($components) == 1
           $color-base = $components
           $color-invert = findColorInvert($color-base)
           $color-light = findLightColor($color-base)
           $color-dark = findDarkColor($color-base)
-        else if typeof($components) == 'list'
-          $color-base = $components[1]
+        else if listTypeofValuesValidator($components, 'rgba|hsla') and length($components) > 1
+          $color-base = $components[0]
           // If Invert, Light and Dark are provided
           if length($components) > 3
-            $color-invert = $components[2]
-            $color-light = $components[3]
-            $color-dark = $components[4]
+            $color-invert = $components[1]
+            $color-light = $components[2]
+            $color-dark = $components[3]
             // If only Invert and Light are provided
           else if length($components) > 2
-            $color-invert = $components[2]
-            $color-light = $components[3]
+            $color-invert = $components[1]
+            $color-light = $components[2]
             $color-dark = findDarkColor($color-base)
             // If only Invert is provided
           else
-            $color-invert = $components[2]
+            $color-invert = $components[1]
             $color-light = findLightColor($color-base)
             $color-dark = findDarkColor($color-base)
 
@@ -48,11 +60,11 @@ mergeColorMaps($bulma-colors, $custom-colors)
         }
 
         // We only want to merge the map if the color base is an actual color
-        if typeof($color-base) == 'color'
+        if match('\b(rgba|hsla)\b', typeof($color-base))
           // We merge this colors elements as map with Bulma's colors map
           // (we can override them this way, no multiple definition for the same name)
           // $merged-colors: map_merge($merged-colors, ($name: ($color-base, $color-invert, $color-light, $color-dark)))
-          $merged-colors = merge($merged-colors, {$name: $value})
+          $merged-colors[$name] = $value
 
   return $merged-colors
 


### PR DESCRIPTION
Literal translation from SASS just doesn't work with Stylus.

Example of usage for custom colors:
```stylus
$custom-colors:= {
	"lime": (lime),
	"tomato": (tomato white),
	"orange": (orange lime red),
	"lavender": (lavender blue white black)
}
```