### PR TITLE
Reorder selectors inside `delete()` mixin like in original Bulma.io

### DIFF
--- a/stylus/utilities/mixins.styl
+++ b/stylus/utilities/mixins.styl
@@ -210,21 +210,21 @@ delete()
   &:active
     background-color rgba($scheme-invert, 0.4)
   // Sizes
-  &.is-small
+  .is-small&
     height 16px
     max-height 16px
     max-width 16px
     min-height 16px
     min-width 16px
     width 16px
-  &.is-medium
+  .is-medium&
     height 24px
     max-height 24px
     max-width 24px
     min-height 24px
     min-width 24px
     width 24px
-  &.is-large
+  .is-large&
     height 32px
     max-height 32px
     max-width 32px


### PR DESCRIPTION
Because SASS and Stylus generates nested rules inside mixins in the different way.

Example:
| Original Bulma.io | Current Bulma Stylus Build |
|---|---|
| `.is-small.delete, .is-small.modal-close`</br>... | `.delete.is-small, .modal-close.is-small`</br>... |