### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,21 +26,19 @@
     "url": "https://github.com/groenroos/bulma-stylus/issues"
   },
   "devDependencies": {
-    "autoprefixer": "9.6.4",
+    "autoprefixer-stylus": "^1.0.0"
     "clean-css-cli": "4.3.0",
-    "postcss-cli": "6.1.3",
     "rimraf": "2.7.1",
-    "stylelint": "^11.1.1",
     "stylus": "^0.54.7"
   },
   "scripts": {
-    "build": "npm run build-clean && npm run build-stylus && npm run build-autoprefix && npm run build-cleancss",
-    "build-autoprefix": "postcss --use autoprefixer --map false --output css/bulma.css css/bulma.css && stylelint css/bulma.css --fix -q",
+    "build": "npm run build-clean && npm run build-autoprefix && npm run build-cleancss",
+    "build-autoprefix": "stylus bulma.styl --out css/bulma.css --sourcemap --use autoprefixer-stylus",
     "build-cleancss": "cleancss -o css/bulma.min.css css/bulma.css",
     "build-clean": "rimraf css",
     "build-stylus": "stylus bulma.styl --out css --sourcemap",
     "deploy": "npm run build",
-    "start": "stylus -w bulma.styl --out css"
+    "start": "stylus -w bulma.styl --out css --use autoprefixer-stylus"
   },
   "files": [
     "css",


### PR DESCRIPTION
Stylelint fixes `sourceMappingURL` and doesn't support Stylus officially. Sourcemap is more important than cosmetic empty lines between the rules in accordance with original Bulma.